### PR TITLE
Improve recording quantization precision

### DIFF
--- a/Assets/Scripts/Tools/ChartRecorder.cs
+++ b/Assets/Scripts/Tools/ChartRecorder.cs
@@ -73,16 +73,18 @@ public sealed class ChartRecorder
 
         var measures = new Dictionary<int, string[]>();
 
+        var secPerRow = secPerMeasure / subdiv;
+
         foreach (var n in notes)
         {
-            var rawTime = n.TimeSec;
+            var rawRow = n.TimeSec / secPerRow;
+            var quantizedRow = (int)Math.Round(rawRow, MidpointRounding.AwayFromZero);
 
-            var measureIndex = (int)Math.Floor(rawTime / secPerMeasure);
-            var inMeasure = rawTime - measureIndex * secPerMeasure;
-            var row = (int)Math.Round((inMeasure / secPerMeasure) * subdiv);
+            if (quantizedRow < 0)
+                quantizedRow = 0;
 
-            if (row >= subdiv) { row = 0; measureIndex += 1; }
-            if (row < 0) { row = 0; }
+            var measureIndex = quantizedRow / subdiv;
+            var row = quantizedRow % subdiv;
 
             if (!measures.TryGetValue(measureIndex, out var rows))
             {


### PR DESCRIPTION
## Summary
- quantize recorded note timing using per-row durations to reduce floating-point drift
- use away-from-zero rounding and clamping before computing measure/row indices for saved charts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69523071de3c832b9912fa50e7213aaf)