### PR TITLE
Allow higher BPM values

### DIFF
--- a/Assets/Scripts/Models/Chart.cs
+++ b/Assets/Scripts/Models/Chart.cs
@@ -4,11 +4,11 @@ using System.Collections.Generic;
 public sealed class Chart
 {
     public string MusicFile { get; }
-    public byte Bpm { get; }
+    public int Bpm { get; }
     public float OffsetSec { get; }
     public IReadOnlyList<Note> Notes { get; }
 
-    public Chart(string musicFile, byte bpm, float offsetSec, IReadOnlyList<Note> notes)
+    public Chart(string musicFile, int bpm, float offsetSec, IReadOnlyList<Note> notes)
     {
         if (bpm <= 0) throw new ArgumentOutOfRangeException(nameof(bpm), "bpm must be > 0");
 

--- a/Assets/Scripts/Models/ChartJson.cs
+++ b/Assets/Scripts/Models/ChartJson.cs
@@ -4,7 +4,7 @@ using System;
 public class ChartJson
 {
     public string musicFile;
-    public byte bpm;
+    public int bpm;
     public float offsetSec;
     public Measure[] measures;
 

--- a/Assets/Scripts/Tools/ChartLoader.cs
+++ b/Assets/Scripts/Tools/ChartLoader.cs
@@ -6,6 +6,8 @@ using UnityEngine;
 
 public static class ChartLoader
 {
+    const int MaxSupportedBpm = 1000;
+
     public static Chart LoadFromStreamingAssets(string fileName)
     {
         var path = Path.Combine(Application.streamingAssetsPath, fileName);
@@ -15,7 +17,8 @@ public static class ChartLoader
                   ?? throw new InvalidDataException($"Failed to parse {nameof(ChartJson)}.");
         raw.measures ??= Array.Empty<ChartJson.Measure>();
 
-        if (raw.bpm <= 0) throw new InvalidDataException($"Invalid bpm: {raw.bpm}");
+        if (raw.bpm <= 0 || raw.bpm > MaxSupportedBpm)
+            throw new InvalidDataException($"Invalid bpm: {raw.bpm} (must be between 1 and {MaxSupportedBpm})");
 
         var secPerBeat = 60.0 / raw.bpm;
         var secPerMeasure = secPerBeat * 4.0;


### PR DESCRIPTION
## Summary
- widen BPM fields to int so charts can represent values above 255
- validate BPM range during chart loading to reject invalid extremes

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ac79e278832b8be13946db985499)