### PR TITLE
Add DFJK keyboard support for gameplay

### DIFF
--- a/Assets/Scripts/Game.cs
+++ b/Assets/Scripts/Game.cs
@@ -134,10 +134,10 @@ public sealed class Game : MonoBehaviour
         var kb = Keyboard.current;
         if (kb == null) return;
 
-        TryHit(Lane.Left, kb.leftArrowKey.wasPressedThisFrame, songTime);
-        TryHit(Lane.Down, kb.downArrowKey.wasPressedThisFrame, songTime);
-        TryHit(Lane.Up, kb.upArrowKey.wasPressedThisFrame, songTime);
-        TryHit(Lane.Right, kb.rightArrowKey.wasPressedThisFrame, songTime);
+        TryHit(Lane.Left, kb.leftArrowKey.wasPressedThisFrame || kb.dKey.wasPressedThisFrame, songTime);
+        TryHit(Lane.Down, kb.downArrowKey.wasPressedThisFrame || kb.fKey.wasPressedThisFrame, songTime);
+        TryHit(Lane.Up, kb.upArrowKey.wasPressedThisFrame || kb.jKey.wasPressedThisFrame, songTime);
+        TryHit(Lane.Right, kb.rightArrowKey.wasPressedThisFrame || kb.kKey.wasPressedThisFrame, songTime);
     }
 
     void TryHit(Lane lane, bool pressed, double songTime)


### PR DESCRIPTION
## Summary
- allow DFJK keys to trigger lane hits alongside arrow keys

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953768faafc832bbfd92c5158faf588)