### PR TITLE
Add UML documentation for project architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,17 @@
+# Architecture UML
+
+The project structure is summarized in the accompanying PlantUML class diagram (`architecture.puml`). The diagram is organized by namespace to show how gameplay, models, tools, judging, and view components interact.
+
+Key relationships captured include:
+- `Game` orchestrates note loading (`ChartLoader`), spawns `NoteView` objects via `NoteViewPool`, records input (`ChartRecorder`), judges timing (`Judge`), and stores the final `JudgementSummary` in `ResultStore`.
+- `ChartLoader` parses `ChartJson` data into runtime `Chart` and `Note` objects using `Lane` and `NoteDivision` classifications.
+- Judging feedback flows through `Judge`, which triggers UI (`JudgementTextPresenter`) and device lighting (`RazerChromaController`) according to `JudgementStyle` colors.
+- Result presentation uses `ResultController`, `ResultJudgementRowView`, and `JudgementStyle` to format per-judgement counts from `ResultStore`.
+
+Render the UML with PlantUML using a compatible renderer (e.g., the PlantUML VS Code extension or the `plantuml` CLI):
+
+```bash
+plantuml docs/architecture.puml
+```
+
+This produces a `architecture.png` (or SVG) illustrating the relationships described above.

--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -1,0 +1,136 @@
+@startuml
+skinparam backgroundColor #FFFFFF
+skinparam classAttributeIconSize 0
+
+package "Gameplay" {
+  class Game {
+    +Start()
+    +Update()
+    +EndToResult()
+  }
+}
+
+package "Models" {
+  class Chart {
+    +MusicFile : string
+    +Bpm : int
+    +OffsetSec : float
+    +Notes : IReadOnlyList<Note>
+  }
+  class ChartJson {
+    +musicFile : string
+    +bpm : int
+    +offsetSec : float
+  }
+  class Note {
+    +TimeSec : double
+    +Lane : Lane
+    +Division : NoteDivision
+  }
+  enum Lane { Left; Down; Up; Right }
+  enum NoteDivision { Quarter; Eighth; Sixteenth }
+  enum Judgement { None; Marvelous; Perfect; Great; Good; Bad; Miss }
+  class ResultStore {
+    +Summary : JudgementSummary
+    +HasSummary : bool
+    +Clear()
+  }
+  class JudgementSummary {
+    +MissCount : int
+    +GetCount(j: Judgement) : int
+  }
+}
+
+package "Tools" {
+  class ChartLoader {
+    +LoadFromStreamingAssets(fileName: string) : Chart
+  }
+  class ChartRecorder {
+    +IsRecording : bool
+    +UpdateHotkeys(chart: Chart)
+    +OnKeyPressed(lane: Lane, songTime: double)
+  }
+  class JudgementCounter {
+    +Record(j: Judgement)
+    +RecordMiss()
+    +CreateSummary() : JudgementSummary
+  }
+  class NoteViewPool {
+    +Rent() : NoteView
+    +Return(view: NoteView)
+  }
+  class RazerChromaController {
+    +TriggerJudgement(j: Judgement, baseColor: Color)
+  }
+  class ResultController {
+    +Retry()
+  }
+  class ColorUtil
+}
+
+package "Judging" {
+  class Judge {
+    +MissWindow : float
+    +JudgeHit(lane: Lane, dt: double) : JudgementOutcome
+  }
+  class JudgementOutcome {
+    +Judgement : Judgement
+    +Intensity : float
+    +ShouldConsumeNote : bool
+  }
+}
+
+package "Views" {
+  class NoteView {
+    +Lane : Lane
+    +TimeSec : double
+    +Division : NoteDivision
+    +Init(note: Note)
+  }
+  class ReceptorHitEffect {
+    +Play(intensity01: float)
+  }
+  class JudgementTextPresenter {
+    +Show(j: Judgement)
+  }
+  class ResultJudgementRowView {
+    +Set(j: Judgement, count: int)
+  }
+  class JudgementStyle {
+    +GetColor(j: Judgement) : Color
+    +GetCountActiveColor() : Color
+    +GetCountInactiveColor() : Color
+  }
+}
+
+Game --> ChartLoader : loads
+Game --> Chart : uses
+Game --> ChartRecorder
+Game --> NoteViewPool
+Game --> Judge
+Game --> ReceptorHitEffect
+Game --> ResultStore : stores summary
+Game --> NoteView : spawns
+
+ChartLoader --> ChartJson : parses
+ChartLoader --> Note
+ChartLoader --> NoteDivision
+ChartLoader --> Lane
+ChartRecorder --> Note
+ChartRecorder --> Chart
+ChartRecorder --> ChartJson
+ChartRecorder --> Lane
+
+Judge --> JudgementTextPresenter
+Judge --> RazerChromaController
+Judge --> JudgementStyle
+Judge --> JudgementOutcome
+JudgementCounter --> JudgementSummary
+ResultController --> ResultStore
+ResultController --> ResultJudgementRowView
+ResultJudgementRowView --> JudgementStyle
+NoteView --> NoteDivision
+JudgementTextPresenter --> JudgementStyle
+RazerChromaController --> Judgement
+
+@enduml


### PR DESCRIPTION
## Summary
- add a PlantUML class diagram capturing major gameplay, judging, model, tool, and view relationships
- document how to render the architecture diagram and highlight key interactions

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956268d7184832b87aea4d613eac76e)