### PR TITLE
Add score tracking and result display

### DIFF
--- a/Assets/Scenes/ResultScene.unity
+++ b/Assets/Scenes/ResultScene.unity
@@ -393,6 +393,147 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c59a09b45696089498aac0967faaac14, type: 3}
+--- !u!1001 &1800000100
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 292644556}
+    m_Modifications:
+    - target: {fileID: 2943350144641168111, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_Name
+      value: Row_Score
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968059025767699762, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968059025767699762, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968059025767699762, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968059025767699762, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968059025767699762, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 460
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8404176251372688083, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8404176251372688083, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8404176251372688083, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8404176251372688083, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8404176251372688083, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2626515026942818176, guid: c59a09b45696089498aac0967faaac14, type: 3}
+      propertyPath: countDigits
+      value: 7
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c59a09b45696089498aac0967faaac14, type: 3}
 --- !u!224 &230286255 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
@@ -418,6 +559,22 @@ RectTransform:
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2626515026942818176, guid: c59a09b45696089498aac0967faaac14, type: 3}
   m_PrefabInstance: {fileID: 1800000000}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c158b5dde541c24a82d003ae2cea411, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Assembly-CSharp::ResultJudgementRowView
+--- !u!224 &1800000102 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
+  m_PrefabInstance: {fileID: 1800000100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1800000101 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2626515026942818176, guid: c59a09b45696089498aac0967faaac14, type: 3}
+  m_PrefabInstance: {fileID: 1800000100}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -455,6 +612,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1800000102}
   - {fileID: 1990192555}
   - {fileID: 459626565}
   - {fileID: 2073408350}
@@ -1350,6 +1508,7 @@ MonoBehaviour:
   rowBad: {fileID: 1311293616}
   rowMiss: {fileID: 230286256}
   rowMaxCombo: {fileID: 1800000001}
+  rowScore: {fileID: 1800000101}
 --- !u!224 &1990192555 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}

--- a/Assets/Scripts/Tools/JudgementCounter.cs
+++ b/Assets/Scripts/Tools/JudgementCounter.cs
@@ -7,6 +7,7 @@ public sealed class JudgementCounter
     int missCount;
     int currentCombo;
     int maxCombo;
+    int score;
 
     public void Reset()
     {
@@ -14,6 +15,7 @@ public sealed class JudgementCounter
         missCount = 0;
         currentCombo = 0;
         maxCombo = 0;
+        score = 0;
     }
 
     public void Record(Judgement judgement)
@@ -24,6 +26,8 @@ public sealed class JudgementCounter
             current = 0;
 
         counts[judgement] = current + 1;
+
+        score += GetScoreFor(judgement);
 
         if (IsComboJudgement(judgement))
         {
@@ -44,15 +48,29 @@ public sealed class JudgementCounter
 
     public JudgementSummary CreateSummary()
     {
-        return new JudgementSummary(counts, missCount, maxCombo);
+        return new JudgementSummary(counts, missCount, maxCombo, score);
     }
 
     public int CurrentCombo => currentCombo;
     public int MaxCombo => maxCombo;
+    public int Score => score;
 
     static bool IsComboJudgement(Judgement judgement)
     {
         return judgement != Judgement.None && judgement <= Judgement.Good;
+    }
+
+    static int GetScoreFor(Judgement judgement)
+    {
+        return judgement switch
+        {
+            Judgement.Marvelous => 1000,
+            Judgement.Perfect => 900,
+            Judgement.Great => 700,
+            Judgement.Good => 500,
+            Judgement.Bad => 200,
+            _ => 0,
+        };
     }
 }
 
@@ -60,16 +78,19 @@ public readonly struct JudgementSummary
 {
     readonly IReadOnlyDictionary<Judgement, int> counts;
     readonly int maxCombo;
+    readonly int score;
 
-    public JudgementSummary(IReadOnlyDictionary<Judgement, int> counts, int missCount, int maxCombo)
+    public JudgementSummary(IReadOnlyDictionary<Judgement, int> counts, int missCount, int maxCombo, int score)
     {
         this.counts = new Dictionary<Judgement, int>(counts);
         MissCount = missCount;
         this.maxCombo = maxCombo;
+        this.score = score;
     }
 
     public int MissCount { get; }
     public int MaxCombo => maxCombo;
+    public int Score => score;
 
     public int GetCount(Judgement judgement)
     {

--- a/Assets/Scripts/Tools/ResultController.cs
+++ b/Assets/Scripts/Tools/ResultController.cs
@@ -11,6 +11,7 @@ public sealed class ResultController : MonoBehaviour
     [SerializeField] ResultJudgementRowView rowBad;
     [SerializeField] ResultJudgementRowView rowMiss;
     [SerializeField] ResultJudgementRowView rowMaxCombo;
+    [SerializeField] ResultJudgementRowView rowScore;
 
     void Start()
     {
@@ -32,6 +33,9 @@ public sealed class ResultController : MonoBehaviour
         if (rowMaxCombo != null)
             rowMaxCombo.SetMaxCombo(s.MaxCombo);
 
+        if (rowScore != null)
+            rowScore.SetScore(s.Score, digits: 7);
+
         ResultStore.Clear();
     }
 
@@ -46,6 +50,9 @@ public sealed class ResultController : MonoBehaviour
 
         if (rowMaxCombo != null)
             rowMaxCombo.SetMaxCombo(0);
+
+        if (rowScore != null)
+            rowScore.SetScore(0, digits: 7);
     }
 
     public void Retry()

--- a/Assets/Scripts/Views/ResultJudgementRowView.cs
+++ b/Assets/Scripts/Views/ResultJudgementRowView.cs
@@ -7,25 +7,32 @@ public sealed class ResultJudgementRowView : MonoBehaviour
     [SerializeField] TMP_Text labelText;
     [SerializeField] TMP_Text countText;
     [SerializeField] JudgementStyle style;
+    [SerializeField] int countDigits = 4;
 
     public void Set(Judgement judgement, int count)
     {
         Set(judgement.ToString().ToUpper(), style.GetColor(judgement), count, style.GetCountActiveColor(), style.GetCountInactiveColor());
     }
 
-    public void Set(string label, Color labelColor, int count, Color countActiveColor, Color countInactiveColor)
+    public void Set(string label, Color labelColor, int count, Color countActiveColor, Color countInactiveColor, int? digitsOverride = null)
     {
         labelText.text = label;
         labelText.color = labelColor;
 
         countText.richText = true;
-        countText.text = BuildCount(count, digits: 4, countActiveColor, countInactiveColor);
+        int digits = digitsOverride ?? countDigits;
+        countText.text = BuildCount(count, Mathf.Max(1, digits), countActiveColor, countInactiveColor);
         countText.color = Color.white;
     }
 
     public void SetMaxCombo(int count)
     {
         Set("MAX COMBO", style.GetMaxComboColor(), count, style.GetCountActiveColor(), style.GetCountInactiveColor());
+    }
+
+    public void SetScore(int score, int digits)
+    {
+        Set("SCORE", style.GetMaxComboColor(), score, style.GetCountActiveColor(), style.GetCountInactiveColor(), digits);
     }
 
     static string BuildCount(int value, int digits, Color active, Color inactive)


### PR DESCRIPTION
## Summary
- track score values per judgement and include them in the result summary
- allow result rows to support configurable digit counts and show a total score row on the result screen

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c80698604832b8aa61ea623765903)