### PR TITLE
Add dance level display to results

### DIFF
--- a/Assets/Scenes/ResultScene.unity
+++ b/Assets/Scenes/ResultScene.unity
@@ -1010,6 +1010,142 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1875000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1875000001}
+  - component: {fileID: 1875000002}
+  - component: {fileID: 1875000003}
+  m_Layer: 5
+  m_Name: DanceLevelText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1875000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1875000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2042671101}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 155}
+  m_SizeDelta: {x: 350, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1875000002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1875000000}
+  m_CullTransparentMesh: 1
+--- !u!114 &1875000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1875000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: AAA
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 54
+  m_fontSizeBase: 54
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1001 &1311293614
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1351,6 +1487,7 @@ MonoBehaviour:
   rowMiss: {fileID: 230286256}
   rowMaxCombo: {fileID: 1800000001}
   scoreText: {fileID: 1064966822}
+  danceLevelText: {fileID: 1875000003}
 --- !u!224 &1990192555 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7537791590301816015, guid: c59a09b45696089498aac0967faaac14, type: 3}
@@ -1552,6 +1689,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1064966820}
+  - {fileID: 1875000001}
   - {fileID: 292644556}
   - {fileID: 931192040}
   m_Father: {fileID: 0}

--- a/Assets/Scripts/Tools/JudgementCounter.cs
+++ b/Assets/Scripts/Tools/JudgementCounter.cs
@@ -78,12 +78,15 @@ public readonly struct JudgementSummary
             GetCount(snapshot, Judgement.Good),
             GetCount(snapshot, Judgement.Bad),
             missCount);
+
+        DanceLevel = ScoreCalculator.GetDanceLevel(Score);
     }
 
     public int MissCount { get; }
     public int MaxCombo => maxCombo;
     public int TotalNotes { get; }
     public int Score { get; }
+    public string DanceLevel { get; }
 
     static int GetCount(IReadOnlyDictionary<Judgement, int> source, Judgement judgement)
     {

--- a/Assets/Scripts/Tools/ResultController.cs
+++ b/Assets/Scripts/Tools/ResultController.cs
@@ -13,6 +13,7 @@ public sealed class ResultController : MonoBehaviour
     [SerializeField] ResultJudgementRowView rowMiss;
     [SerializeField] ResultJudgementRowView rowMaxCombo;
     [SerializeField] TMP_Text scoreText;
+    [SerializeField] TMP_Text danceLevelText;
 
     void Start()
     {
@@ -37,6 +38,9 @@ public sealed class ResultController : MonoBehaviour
         if (scoreText != null)
             scoreText.text = $"SCORE {s.Score:0000000}";
 
+        if (danceLevelText != null)
+            danceLevelText.text = s.DanceLevel;
+
         ResultStore.Clear();
     }
 
@@ -54,6 +58,9 @@ public sealed class ResultController : MonoBehaviour
 
         if (scoreText != null)
             scoreText.text = "SCORE 0000000";
+
+        if (danceLevelText != null)
+            danceLevelText.text = ScoreCalculator.GetDanceLevel(0);
     }
 
     public void Retry()

--- a/Assets/Scripts/Tools/ScoreCalculator.cs
+++ b/Assets/Scripts/Tools/ScoreCalculator.cs
@@ -19,4 +19,26 @@ public static class ScoreCalculator
 
         return (int)(basePoint * weighted);
     }
+
+    public static string GetDanceLevel(int score, bool failed = false)
+    {
+        if (failed) return "E";
+
+        if (score >= 990_000) return "AAA";
+        if (score >= 950_000) return "AA+";
+        if (score >= 900_000) return "AA";
+        if (score >= 890_000) return "AA-";
+        if (score >= 850_000) return "A+";
+        if (score >= 800_000) return "A";
+        if (score >= 790_000) return "A-";
+        if (score >= 750_000) return "B+";
+        if (score >= 700_000) return "B";
+        if (score >= 690_000) return "B-";
+        if (score >= 650_000) return "C+";
+        if (score >= 600_000) return "C";
+        if (score >= 590_000) return "C-";
+        if (score >= 550_000) return "D+";
+
+        return "D";
+    }
 }


### PR DESCRIPTION
## Summary
- add DDR-style dance level thresholds and expose them from score calculations
- surface the calculated dance level on the result screen UI
- initialize the result view with a dedicated dance level text element
- align GetDanceLevel ranges to the DDR reference table, including failed-to-E handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c90e19d50832b9d0ff2417ebab439)