### PR TITLE
Add song display names

### DIFF
--- a/Assets/Scripts/Models/SongDefinition.cs
+++ b/Assets/Scripts/Models/SongDefinition.cs
@@ -6,6 +6,8 @@ public sealed class SongDefinition
 {
     public string songId = "dance-mood";
 
+    public string songName = "Dance Mood";
+
     public AudioClip musicClip;
 
     public string chartFileName = "chart.json";

--- a/Assets/Scripts/Views/SongRowView.cs
+++ b/Assets/Scripts/Views/SongRowView.cs
@@ -1,4 +1,5 @@
-﻿using TMPro;
+﻿using System;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -20,7 +21,7 @@ public sealed class SongRowView : MonoBehaviour
         this.owner = owner;
         this.index = index;
 
-        titleText.text = song.songId;
+        titleText.text = string.IsNullOrWhiteSpace(song.songName) ? song.songId : song.songName;
 
         button.onClick.RemoveAllListeners();
         button.onClick.AddListener(() => owner.OnRowClicked(index));

--- a/Assets/Settings/SongLibrary.asset
+++ b/Assets/Settings/SongLibrary.asset
@@ -14,8 +14,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::SongLibrary
   songs:
   - songId: dance-mood
+    songName: Dance Mood
     musicClip: {fileID: 8300000, guid: c4c12f28566ea654482a64cb013d652f, type: 3}
     chartFileName: chart.json
   - songId: starry-stella
+    songName: Starry Stella
     musicClip: {fileID: 8300000, guid: 7a8d53f874a23b14297f9dede9aeb354, type: 3}
     chartFileName: chart.json


### PR DESCRIPTION
### Motivation
- Provide a dedicated, human-friendly display name for songs that is independent from the `songId` used for file paths and identifiers.  
- Allow entries like `dance-mood` to show as `Dance Mood` and `starry-stella` as `Starry Stella` in the UI.  
- Keep the `songId` as the canonical identifier while letting the UI present a nicer label.  

### Description
- Added a `songName` field to `SongDefinition` with a default value.  
- Updated the song list row view (`SongRowView.cs`) to display `song.songName` with a fallback to `song.songId` when `songName` is empty.  
- Updated `Assets/Settings/SongLibrary.asset` to include `songName` values for the existing songs.  

### Testing
- No automated tests were run against these changes.  
- Changes are limited to the data model, UI binding, and asset defaults and should not affect gameplay logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f3680a560832bb49a08d669446bb1)