### PR TITLE
Update .gitignore to ignore .NET build artifacts and NuGet packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@
 /[Uu]ser[Ss]ettings/
 *.log
 
+# .NET build artifacts
+/[Bb]in/
+*.nupkg
+*.snupkg
+
 # By default unity supports Blender asset imports, *.blend1 blender files do not need to be commited to version control.
 *.blend1
 *.blend1.meta


### PR DESCRIPTION
### Motivation
- Prevent check-in of common .NET build artifacts that should not be tracked in the repository.
- Avoid committing generated NuGet packages which are binary build outputs.
- Keep the repository clean and consistent with typical .NET/Unity project ignores.

### Description
- Added `.NET` build artifact ignores to the root `.gitignore` including the `/<Bb>in/` directory pattern.
- Added `*.nupkg` and `*.snupkg` patterns to exclude NuGet package files.
- Preserved existing Unity-related ignore rules and project-specific ignores.

### Testing
- No automated tests were run for this change.
- No test failures reported because no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696112b63718832b8c488689b2f03f96)