### PR TITLE
Apply DDR scoring: 10-point base rounding and per-judgement adjustments

### DIFF
--- a/Assets/Scripts/Tools/ScoreCalculator.cs
+++ b/Assets/Scripts/Tools/ScoreCalculator.cs
@@ -7,17 +7,21 @@ public static class ScoreCalculator
         if (totalNotes <= 0)
             return 0;
 
-        double basePoint = (double)MaxScore / totalNotes;
+        int basePoint = MaxScore / totalNotes;
+        basePoint = (basePoint / 10) * 10;
 
-        double weighted =
-            marvelous * 1.00 +
-            perfect * 0.98 +
-            great * 0.60 +
-            good * 0.20 +
-            bad * 0.00 +
-            miss * 0.00;
+        int marvelousScore = basePoint;
+        int perfectScore = basePoint - 10;
+        int greatScore = (basePoint * 60 / 100) - 10;
+        int goodScore = (basePoint * 20 / 100) - 10;
 
-        return (int)(basePoint * weighted);
+        return
+            marvelous * marvelousScore +
+            perfect * perfectScore +
+            great * greatScore +
+            good * goodScore +
+            bad * 0 +
+            miss * 0;
     }
 
     public static string GetDanceLevel(int score, bool failed = false)

--- a/Assets/Tests/Editor/ScoreCalculatorTests.cs
+++ b/Assets/Tests/Editor/ScoreCalculatorTests.cs
@@ -11,13 +11,13 @@ public class ScoreCalculatorTests
     }
 
     [TestCase(100, 100, 0, 0, 0, 0, 0, 1_000_000)]
-    [TestCase(100, 0, 100, 0, 0, 0, 0, 980_000)]
-    [TestCase(100, 0, 0, 100, 0, 0, 0, 600_000)]
-    [TestCase(100, 0, 0, 0, 100, 0, 0, 200_000)]
+    [TestCase(100, 0, 100, 0, 0, 0, 0, 999_000)]
+    [TestCase(100, 0, 0, 100, 0, 0, 0, 599_000)]
+    [TestCase(100, 0, 0, 0, 100, 0, 0, 199_000)]
     [TestCase(100, 0, 0, 0, 0, 100, 0, 0)]
     [TestCase(100, 0, 0, 0, 0, 0, 100, 0)]
-    [TestCase(100, 50, 50, 0, 0, 0, 0, 990_000)]
-    [TestCase(3, 1, 1, 1, 0, 0, 0, 860_000)]
+    [TestCase(100, 50, 50, 0, 0, 0, 0, 999_500)]
+    [TestCase(3, 1, 1, 1, 0, 0, 0, 866_638)]
     public void Calculate_UsesWeightedScores(
         int totalNotes,
         int marvelous,


### PR DESCRIPTION
### Motivation
- Implement the DDR score calculation formula where the base point is `1_000_000 / totalNotes` rounded down to the nearest 10 and judgement scores follow the specified percentages with -10 adjustments. 
- Replace the previous fractional weight approach with integer per-judgement point values to match the referenced specification.

### Description
- Update `ScoreCalculator.Calculate` to compute `basePoint = MaxScore / totalNotes` and round it down to a 10-point unit, then compute per-judgement points (`marvelous`, `perfect`, `great`, `good`) and sum their integer contributions. 
- Set `perfect` to `basePoint - 10`, `great` to `(basePoint * 60 / 100) - 10`, `good` to `(basePoint * 20 / 100) - 10`, and leave `bad`/`miss` as zero. 
- Remove the previous floating-point weighted calculation and return the integer total directly. 
- Update unit test expected values in `Assets/Tests/Editor/ScoreCalculatorTests.cs` to match the new scoring logic.

### Testing
- The unit tests in `Assets/Tests/Editor/ScoreCalculatorTests.cs` have been updated to reflect the new expected scores. 
- No automated tests (NUnit) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69611f0ec724832b900122353745932a)