### PR TITLE
Split JudgementOutcome into its own file

### DIFF
--- a/Assets/Scripts/Judges/Judge.cs
+++ b/Assets/Scripts/Judges/Judge.cs
@@ -49,17 +49,3 @@ public sealed class Judge
         return new JudgementOutcome(judgement, intensity, dt <= miss);
     }
 }
-
-public readonly struct JudgementOutcome
-{
-    public JudgementOutcome(Judgement judgement, float intensity, bool shouldConsumeNote)
-    {
-        Judgement = judgement;
-        Intensity = intensity;
-        ShouldConsumeNote = shouldConsumeNote;
-    }
-
-    public Judgement Judgement { get; }
-    public float Intensity { get; }
-    public bool ShouldConsumeNote { get; }
-}

--- a/Assets/Scripts/Judges/JudgementOutcome.cs
+++ b/Assets/Scripts/Judges/JudgementOutcome.cs
@@ -1,0 +1,16 @@
+using System;
+
+[Serializable]
+public readonly struct JudgementOutcome
+{
+    public JudgementOutcome(Judgement judgement, float intensity, bool shouldConsumeNote)
+    {
+        Judgement = judgement;
+        Intensity = intensity;
+        ShouldConsumeNote = shouldConsumeNote;
+    }
+
+    public Judgement Judgement { get; }
+    public float Intensity { get; }
+    public bool ShouldConsumeNote { get; }
+}


### PR DESCRIPTION
### Motivation
- Separate the `JudgementOutcome` data type from `Judge.cs` so `Judge` remains focused on judgement logic.
- Make `JudgementOutcome` easier to locate and reuse across the codebase by giving it its own file.
- Improve readability and reduce the size of `Assets/Scripts/Judges/Judge.cs`.

### Description
- Removed the `JudgementOutcome` struct from `Assets/Scripts/Judges/Judge.cs` and left `Judge.JudgeHit` behavior unchanged.
- Added `Assets/Scripts/Judges/JudgementOutcome.cs` containing the `[Serializable]` `JudgementOutcome` readonly struct with the same constructor and properties (`Judgement`, `Intensity`, `ShouldConsumeNote`).
- No changes were made to judgement logic or public APIs beyond the type being moved.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69613a32c38c832b8d7dc90cb270748b)