### PR TITLE
Add Unity meta file for JudgementOutcome.cs

### DIFF
--- a/Assets/Scripts/Judges/JudgementOutcome.cs.meta
+++ b/Assets/Scripts/Judges/JudgementOutcome.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d4b10b39dab74a97a9bd560b2b02ba7c


### PR DESCRIPTION
### Motivation
- Unity requires `.meta` files to maintain stable asset GUIDs and metadata across checkouts.
- `Assets/Scripts/Judges/JudgementOutcome.cs` did not have a corresponding `.meta` file, which can lead to inconsistent references in the project.
- Adding the `.meta` file ensures the asset has a stable GUID and consistent project behavior.

### Description
- Add `Assets/Scripts/Judges/JudgementOutcome.cs.meta` containing `fileFormatVersion: 2` and `guid: d4b10b39dab74a97a9bd560b2b02ba7c`.
- The new file is placed alongside `JudgementOutcome.cs` to keep asset metadata consistent with other scripts in the folder.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69613e47eec8832b86e640be3d47fbf6)