### PR TITLE
Remove JSON chart loading from ChartLoader

### DIFF
--- a/Assets/_Project/Scripts/Tools/ChartLoader.cs
+++ b/Assets/_Project/Scripts/Tools/ChartLoader.cs
@@ -14,62 +14,10 @@ public static class ChartLoader
         var path = Path.Combine(Application.streamingAssetsPath, fileName);
         var extension = Path.GetExtension(fileName).ToLowerInvariant();
 
-        return extension is ".sm" or ".ssc"
-            ? LoadFromSm(path, difficulty)
-            : LoadFromJson(path);
-    }
+        if (extension is ".sm" or ".ssc")
+            return LoadFromSm(path, difficulty);
 
-    static Chart LoadFromJson(string path)
-    {
-        var json = File.ReadAllText(path);
-
-        var raw = JsonUtility.FromJson<ChartJson>(json)
-                  ?? throw new InvalidDataException($"Failed to parse {nameof(ChartJson)}.");
-        raw.measures ??= Array.Empty<Measure>();
-
-        if (raw.bpm <= 0 || raw.bpm > MaxSupportedBpm)
-            throw new InvalidDataException($"Invalid bpm: {raw.bpm} (must be between 1 and {MaxSupportedBpm})");
-
-        var notes = new List<Note>(1024);
-        var secPerBeat = 60.0 / raw.bpm;
-        var secPerMeasure = secPerBeat * 4.0;
-
-        for (int m = 0; m < raw.measures.Length; m++)
-        {
-            var measure = raw.measures[m];
-            if (measure == null) continue;
-
-            var subdiv = measure.subdiv <= 0 ? 16 : measure.subdiv;
-            var rows = measure.rows ?? Array.Empty<string>();
-
-            var rowCount = Math.Min(subdiv, rows.Length);
-
-            for (int r = 0; r < rowCount; r++)
-            {
-                var row = rows[r] ?? "0000";
-
-                for (int laneIndex = 0; laneIndex < 4 && laneIndex < row.Length; laneIndex++)
-                {
-                    if (row[laneIndex] != '1') continue;
-
-                    var timeSec =
-                        raw.offsetSec
-                        + (m * secPerMeasure)
-                        + ((double)r / subdiv) * secPerMeasure;
-
-                    var division = DivisionFromRow(r);
-
-                    notes.Add(new Note(
-                        timeSec,
-                        (Lane)laneIndex,
-                        division
-                    ));
-                }
-            }
-        }
-
-        var ordered = notes.OrderBy(n => n.TimeSec).ToList();
-        return new Chart(raw.musicFile, raw.bpm, raw.offsetSec, ordered);
+        throw new InvalidDataException($"Unsupported chart format: {extension}");
     }
 
     static Chart LoadFromSm(string path, ChartDifficulty difficulty)


### PR DESCRIPTION
### Motivation
- The project migrated chart data to `.sm` files, making the JSON chart path obsolete.
- Removing JSON parsing reduces maintenance and prevents accidental use of a deprecated format.
- Enforce a clear runtime failure for unsupported chart file extensions.

### Description
- Removed the `LoadFromJson` implementation and all JSON parsing logic from `ChartLoader`.
- Updated `LoadFromStreamingAssets` to only accept `.sm` and `.ssc` and to call `LoadFromSm` for those formats.
- Added an explicit `InvalidDataException` for unsupported file extensions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696327a2cdb0832b9990ce8e7b5271e0)