### PR TITLE
Remove unused note division helper

### DIFF
--- a/Assets/_Project/Scripts/Tools/ChartLoader.cs
+++ b/Assets/_Project/Scripts/Tools/ChartLoader.cs
@@ -210,13 +210,6 @@ public static class ChartLoader
             : fallback;
     }
 
-    static NoteDivision DivisionFromRow(int row)
-    {
-        if (row % 4 == 0) return NoteDivision.Quarter;
-        if (row % 2 == 0) return NoteDivision.Eighth;
-        return NoteDivision.Sixteenth;
-    }
-
     static NoteDivision DivisionFromRow(int row, int rowsPerMeasure)
     {
         if (rowsPerMeasure <= 0)


### PR DESCRIPTION
### Motivation
- General code cleanup to remove unused methods and reduce maintenance surface.
- The project contained a redundant note-division helper that was never referenced.
- Removing dead code aligns with the request to delete unused methods, variables, classes, and files.

### Description
- Deleted the unused static method `DivisionFromRow(int row)` from `Assets/_Project/Scripts/Tools/ChartLoader.cs`.
- Retained the used overload `DivisionFromRow(int row, int rowsPerMeasure)` which is referenced by the parser.
- No other functional changes were made to parsing or chart loading logic.

### Testing
- No automated tests were executed for this change.
- The modification is a simple removal of an unreferenced helper and does not alter runtime logic when the remaining overload is used.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69633c563230832b881e0f38eb959c48)