### PR TITLE
Allow notes to pass the judge line on miss

### DIFF
--- a/Assets/_Project/Scripts/Scenes/Play/PlayController.cs
+++ b/Assets/_Project/Scripts/Scenes/Play/PlayController.cs
@@ -191,7 +191,7 @@ public sealed class PlayController : MonoBehaviour
             foreach (var n in active[lane])
             {
                 var t = (float)((n.TimeSec - songTime) / travelTimeSec);
-                var y = Mathf.Lerp(judgeLineY.position.y, spawnY.position.y, Mathf.Clamp01(t));
+                var y = Mathf.LerpUnclamped(judgeLineY.position.y, spawnY.position.y, t);
                 var x = GetLaneX(lane);
                 n.transform.position = new Vector3(x, y, 0);
             }


### PR DESCRIPTION
### Motivation
- Prevent notes from stopping at the judge line when they are too early or missed, so missed notes visually pass through the lane instead of freezing at the receptor.
- The current interpolation clamps positions at the judge line, causing incorrect visual behavior for late notes.

### Description
- Replaced clamped interpolation in `PlayController.UpdateNotePositions` with unclamped interpolation by changing `Mathf.Lerp(..., Mathf.Clamp01(t))` to `Mathf.LerpUnclamped(..., t)` in `Assets/_Project/Scripts/Scenes/Play/PlayController.cs`.
- This lets notes continue moving beyond the judge line when `t` falls outside the [0,1] range while keeping spawning and hit/miss logic unchanged.

### Testing
- No automated tests were executed for this change.
- Manual playtesting in the Unity editor is recommended to verify that missed notes now pass through the judge line visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963a7a9c8a8832baaba70461460b2d7)