### PR TITLE
Add hit burst effect colored by judgement

### DIFF
--- a/Assets/_Project/Scripts/Judges/Judge.cs
+++ b/Assets/_Project/Scripts/Judges/Judge.cs
@@ -17,6 +17,7 @@ public sealed class Judge
     [SerializeField] JudgementStyle style;
 
     public float MissWindow => miss;
+    public JudgementStyle Style => style;
 
     public JudgementOutcome JudgeHit(Lane lane, double dt)
     {

--- a/Assets/_Project/Scripts/Scenes/Play/PlayController.cs
+++ b/Assets/_Project/Scripts/Scenes/Play/PlayController.cs
@@ -38,6 +38,7 @@ public sealed class PlayController : MonoBehaviour
     [Header("Judgement")]
     [SerializeField] Judge judge;
     [SerializeField] ComboTextPresenter comboText;
+    [SerializeField] JudgementStyle judgementStyle;
 
     [SerializeField] float endFadeOutSec = 0.4f;
 
@@ -229,7 +230,7 @@ public sealed class PlayController : MonoBehaviour
         {
             counter.Record(judgement.Judgement);
             list.RemoveFirst();
-            notePool.Return(note);
+            PlayBurstAndReturn(note, judgement.Judgement);
             UpdateComboDisplay();
         }
     }
@@ -247,7 +248,7 @@ public sealed class PlayController : MonoBehaviour
                 counter.RecordMiss();
                 Debug.Log($"{lane}: Miss (late)");
                 list.RemoveFirst();
-                notePool.Return(n);
+                PlayBurstAndReturn(n, Judgement.Miss);
 
                 UpdateComboDisplay();
             }
@@ -274,6 +275,18 @@ public sealed class PlayController : MonoBehaviour
     void UpdateComboDisplay()
     {
         comboText?.Show(counter.CurrentCombo);
+    }
+
+    void PlayBurstAndReturn(NoteView note, Judgement judgement)
+    {
+        var style = judgementStyle != null ? judgementStyle : judge?.Style;
+        if (style == null)
+        {
+            notePool.Return(note);
+            return;
+        }
+
+        note.PlayHitBurst(style.GetColor(judgement), () => notePool.Return(note));
     }
 
     public void EndToResult()


### PR DESCRIPTION
### Motivation
- Add a visual burst effect when notes disappear to emphasize hits and misses. 
- Use the same judgement colors as the judgement text (e.g. `Perfect` = yellow, `Great` = green) so hit feedback is consistent. 
- Defer returning notes to the pool until the burst animation finishes to avoid visual popping. 

### Description
- Exposed the `JudgementStyle` from `Judge` via a new `Judge.Style` property to allow other systems to query judgement colors. 
- Implemented a burst animation in `NoteView` with serialized parameters `burstDuration` and `burstScale`, and added `PlayHitBurst` / `CoHitBurst` to animate scale and fade using a supplied color. 
- Updated `PlayController` to add an optional `judgementStyle` field and to call a new `PlayBurstAndReturn` helper that looks up the colour (`judgementStyle` or `judge.Style`) and plays the burst before returning the note to the pool. 
- Ensured misses also run through `PlayBurstAndReturn` so both hits and late misses get the burst effect. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963aaba50cc832b92dba6323ebbfa2d)