### PR TITLE
Set default note travel time to 3s to restore 1x scroll spacing

### DIFF
--- a/Assets/_Project/Scenes/PlayScene.unity
+++ b/Assets/_Project/Scenes/PlayScene.unity
@@ -479,7 +479,7 @@ MonoBehaviour:
   notePrefab: {fileID: 422535996257625606, guid: a8809871df1d4744d972c86de5a7a7f5, type: 3}
   spawnY: {fileID: 1098005563}
   judgeLineY: {fileID: 698216054}
-  travelTimeSec: 1.5
+  travelTimeSec: 3
   laneXs:
   - -3
   - -1

--- a/Assets/_Project/Scripts/Scenes/PlayScene/PlayScene.cs
+++ b/Assets/_Project/Scripts/Scenes/PlayScene/PlayScene.cs
@@ -19,7 +19,7 @@ public sealed class PlayScene : MonoBehaviour
     [SerializeField] NoteView notePrefab;
     [SerializeField] Transform spawnY;
     [SerializeField] Transform judgeLineY;
-    [SerializeField] float travelTimeSec = 1.5f;
+    [SerializeField] float travelTimeSec = 3f;
 
     [Header("Lane X positions (Left, Down, Up, Right)")]
     [SerializeField] float[] laneXs = { -3f, -1f, 1f, 3f };


### PR DESCRIPTION
### Motivation
- The displayed note spacing behaved like a 2x scroll speed, leaving an extra full-note gap between 4th notes instead of being contiguous. 
- The visual spacing is controlled by the note travel duration used to map time to screen position, so increasing the travel duration restores the intended 1x spacing. 

### Description
- Change default `travelTimeSec` in `PlayScene` from `1.5f` to `3f` in `Assets/_Project/Scripts/Scenes/PlayScene/PlayScene.cs`.
- Update the serialized `travelTimeSec` value in `Assets/_Project/Scenes/PlayScene.unity` to `3` to match the new default.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964f1043f60832bb485e693cd7ec19a)