### PR TITLE
Restrict ChartLoader to .sm files

### DIFF
--- a/Assets/_Project/Scripts/Tools/ChartLoader.cs
+++ b/Assets/_Project/Scripts/Tools/ChartLoader.cs
@@ -14,7 +14,7 @@ public static class ChartLoader
         var path = Path.Combine(Application.streamingAssetsPath, fileName);
         var extension = Path.GetExtension(fileName).ToLowerInvariant();
 
-        if (extension is ".sm" or ".ssc")
+        if (extension is ".sm")
             return LoadFromSm(path, difficulty);
 
         throw new InvalidDataException($"Unsupported chart format: {extension}");


### PR DESCRIPTION
### Motivation
- Limit supported simfile formats so the chart loader only attempts to parse `.sm` files and not `.ssc` files.
- Avoid silently accepting formats the existing parser does not fully support.
- Make format handling explicit so unsupported files produce a clear error via `InvalidDataException`.

### Description
- Updated `Assets/_Project/Scripts/Tools/ChartLoader.cs` to change the extension check in `LoadFromStreamingAssets` from `".sm" or ".ssc"` to only `".sm"`.
- The method now calls `LoadFromSm` only for `.sm` files and throws an `InvalidDataException` for any other extension.
- No changes were made to the `LoadFromSm` parsing logic or other parts of the file.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69659ca989b8832ba9166e9439ac05cf)