### PR TITLE
Shift song selection reel to the right

### DIFF
--- a/Assets/_Project/Scenes/SongSelectScene.unity
+++ b/Assets/_Project/Scenes/SongSelectScene.unity
@@ -785,10 +785,10 @@ MonoBehaviour:
   previewStartTimeSec: 0
   previewFadeOutSeconds: 0.15
   preloadRadius: 1
-  centerX: -20
+  centerX: 180
   centerY: 0
   spacingY: 110
-  rightXMax: 80
+  rightXMax: 280
   xOffsetByAbsIndex:
     serializedVersion: 2
     m_Curve:


### PR DESCRIPTION
### Motivation
- Move the song selection reel to the right as the first step toward adding a chart/difficulty selection UI so the reel leaves space for the new UI elements.

### Description
- Adjusted reel layout values in `Assets/_Project/Scenes/SongSelectScene.unity` by changing `centerX` from `-20` to `180` and `rightXMax` from `80` to `280` to shift the visible reel to the right.

### Testing
- No automated tests were run since this is a visual layout tweak only and does not affect runtime logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967a3b08a98832ba6af718ad508e762)