### PR TITLE
Defer SongSelectScene asset loading to background

### DIFF
--- a/Assets/_Project/Scripts/Scenes/SongSelectScene/SongSelectScene.cs
+++ b/Assets/_Project/Scripts/Scenes/SongSelectScene/SongSelectScene.cs
@@ -63,11 +63,12 @@ public sealed class SongSelectScene : MonoBehaviour
 
     IEnumerator Start()
     {
-        yield return BuildCatalogAndLoadAssets();
+        songs = SongCatalog.BuildCatalog();
         BuildList();
         PreloadNearbyPreviewAudio(selectedIndex);
         UpdateLeftPanel();
         PlayPreview();
+        StartCoroutine(LoadAssetsInBackground());
     }
 
     void Update()
@@ -92,10 +93,8 @@ public sealed class SongSelectScene : MonoBehaviour
         ApplyReelLayout();
     }
 
-    IEnumerator BuildCatalogAndLoadAssets()
+    IEnumerator LoadAssetsInBackground()
     {
-        songs = SongCatalog.BuildCatalog();
-
         for (int i = 0; i < songs.Count; i++)
         {
             var song = songs[i];


### PR DESCRIPTION
### Motivation
- Reduce initial UI wait by building the song list immediately and performing heavy asset loads asynchronously in the background.
- Allow preview audio and left-panel UI to initialize before full audio/texture assets are loaded.

### Description
- Call `SongCatalog.BuildCatalog()` in `Start()` and immediately run `BuildList()`, `PreloadNearbyPreviewAudio()`, `UpdateLeftPanel()`, and `PlayPreview()` so the UI is responsive at startup.
- Replace `BuildCatalogAndLoadAssets()` with `LoadAssetsInBackground()` and start it via `StartCoroutine(LoadAssetsInBackground())` from `Start()` so audio and textures are loaded incrementally.
- Moved catalog construction out of the asset-loading coroutine and renamed the routine to reflect background behavior in `Assets/_Project/Scripts/Scenes/SongSelectScene/SongSelectScene.cs`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967c3c7d5b8832b81f4fd7f0080302f)