### PR TITLE
Show chart difficulty in result info

### DIFF
--- a/Assets/_Project/Scripts/Models/ResultStore.cs
+++ b/Assets/_Project/Scripts/Models/ResultStore.cs
@@ -4,11 +4,13 @@ public static class ResultStore
     public static bool HasSummary { get; set; }
     public static string SongTitle { get; set; }
     public static string MusicSource { get; set; }
+    public static ChartDifficulty? ChartDifficulty { get; set; }
 
     public static void Clear()
     {
         HasSummary = false;
         SongTitle = null;
         MusicSource = null;
+        ChartDifficulty = null;
     }
 }

--- a/Assets/_Project/Scripts/Scenes/PlayScene/PlayScene.cs
+++ b/Assets/_Project/Scripts/Scenes/PlayScene/PlayScene.cs
@@ -326,6 +326,7 @@ public sealed class PlayScene : MonoBehaviour
         {
             ResultStore.SongTitle = currentSong.DisplayTitle;
             ResultStore.MusicSource = string.IsNullOrWhiteSpace(currentSong.Artist) ? string.Empty : currentSong.Artist;
+            ResultStore.ChartDifficulty = currentSong.ChartDifficulty;
         }
 
         SceneManager.LoadScene(nameof(ResultScene));

--- a/Assets/_Project/Scripts/Scenes/ResultScene/ResultScene.cs
+++ b/Assets/_Project/Scripts/Scenes/ResultScene/ResultScene.cs
@@ -75,7 +75,21 @@ public sealed class ResultScene : MonoBehaviour
             songTitleText.text = ResultStore.SongTitle ?? string.Empty;
 
         if (musicSourceText != null)
-            musicSourceText.text = ResultStore.MusicSource ?? string.Empty;
+            musicSourceText.text = BuildMusicSourceText();
+    }
+
+    static string BuildMusicSourceText()
+    {
+        var source = ResultStore.MusicSource ?? string.Empty;
+        var difficulty = ResultStore.ChartDifficulty?.ToString();
+
+        if (string.IsNullOrEmpty(source))
+            return difficulty ?? string.Empty;
+
+        if (string.IsNullOrEmpty(difficulty))
+            return source;
+
+        return $"{source} / {difficulty}";
     }
 
     public void Retry()


### PR DESCRIPTION
### Motivation
- Persist and display the selected chart difficulty on the result screen so players can see which difficulty was played along with the song/artist info.

### Description
- Add a nullable `ChartDifficulty? ChartDifficulty` to `ResultStore` and clear it in `Clear()`; set `ResultStore.ChartDifficulty = currentSong.ChartDifficulty` when ending a play in `PlayScene` and update `ResultScene` to compose `musicSourceText` from `ResultStore.MusicSource` and `ResultStore.ChartDifficulty` via `BuildMusicSourceText()`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696850be2134832b82ad577da7d96b0c)